### PR TITLE
Fix executeSale logic in NFTMarketplace

### DIFF
--- a/contracts/NFTMarketplace.sol
+++ b/contracts/NFTMarketplace.sol
@@ -2,7 +2,22 @@
 pragma solidity ^0.8.0;
 
 import "hardhat/console.sol";
-import "@openzeppelin/contracts/utils/Counters.sol";
+// Minimal counter library used to track incremental ids
+library Counters {
+    struct Counter {
+        uint256 _value;
+    }
+
+    function current(Counter storage counter) internal view returns (uint256) {
+        return counter._value;
+    }
+
+    function increment(Counter storage counter) internal {
+        unchecked {
+            counter._value += 1;
+        }
+    }
+}
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
@@ -150,8 +165,9 @@ contract NFTMarketplace is ERC721URIStorage {
         address seller = idToListedNFT[tokenId].seller;
         require(msg.value == price, "Please submit the asking price in order to complete the purchase");
 
-        idToListedNFT[tokenId].currentlyListed = true;
+        idToListedNFT[tokenId].currentlyListed = false;
         idToListedNFT[tokenId].seller = payable(msg.sender);
+        idToListedNFT[tokenId].owner = payable(msg.sender);
         _itemsSold.increment();
 
         _transfer(address(this), msg.sender, tokenId);


### PR DESCRIPTION
## Summary
- update `executeSale` so items are delisted and ownership updated
- implement a local `Counters` library since OpenZeppelin version doesn't include it

## Testing
- `npx hardhat test` *(fails: couldn't download compiler due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685202e233c4832582321d9988f924e3